### PR TITLE
Modified code to properly propogate openldap errors, also added a reg…

### DIFF
--- a/keystone/common/config.py
+++ b/keystone/common/config.py
@@ -24,6 +24,14 @@ _SSO_CALLBACK = '/etc/keystone/sso_callback_template.html'
 
 FILE_OPTIONS = {
     None: [
+
+        cfg.StrOpt('password_regex',default='',
+                   help='The regular expression for strength test of the password'),
+
+        cfg.StrOpt('password_regex_message',default='Password not strong enough',
+                   help='The message shown to the user when the password strength check fails '),
+                   
+
         cfg.StrOpt('admin_token', secret=True, default='ADMIN',
                    help='A "shared secret" that can be used to bootstrap '
                         'Keystone. This "token" does not represent a user, '
@@ -635,6 +643,9 @@ FILE_OPTIONS = {
         cfg.StrOpt('user_default_project_id_attribute',
                    help='LDAP attribute mapped to default_project_id for '
                         'users.'),
+        cfg.StrOpt('user_locked_time_attribute',
+                    help='Time user account was'
+                         ' locked'),
         cfg.BoolOpt('user_allow_create', default=True,
                     help='Allow user creation in LDAP backend.'),
         cfg.BoolOpt('user_allow_update', default=True,

--- a/keystone/common/models.py
+++ b/keystone/common/models.py
@@ -94,11 +94,12 @@ class User(Model):
         email
         enabled (bool, default True)
         default_project_id
+        locked_time
     """
 
     required_keys = ('id', 'name', 'domain_id')
     optional_keys = ('password', 'description', 'email', 'enabled',
-                     'default_project_id')
+                     'default_project_id', 'locked_time')
 
 
 class Group(Model):


### PR DESCRIPTION
Following changes are made.
1) Give proper message and 400 error if account is locked in openldap
2) Give proper message and 400 error id password syntax does not match openldap policy.
3) Add ability to validate the keystone user's password using a regular expression.
